### PR TITLE
KS dependent priorities of partitions

### DIFF
--- a/mounter.c
+++ b/mounter.c
@@ -838,28 +838,28 @@ static void AddNode(struct PartitionBlock *part, struct ParameterPacket *pp, str
 	struct ExecBase *SysBase = md->SysBase;
 	struct ExpansionBase *ExpansionBase = md->ExpansionBase;
 	struct DosLibrary *DOSBase = md->DOSBase;
-	
+	LONG bootPri;
 	char bootname[8];
 	UWORD major;
 	
-	major=(ExpansionBase->LibNode.lib_Version)%100;         // we assume versionnumber is under 100, but better safe then sorry
+	major=(ExpansionBase->LibNode.lib_Version)%100;  // we assume version number is under 100, but better safe than sorry
 	bootname[0]=0x06;
 	bootname[1]='B';
 	bootname[2]='O';
-        bootname[3]='O';
-  	bootname[4]='T';
+	bootname[3]='O';
+	bootname[4]='T';
 	bootname[5]=0x30+(major/10);
 	bootname[6]=0x30+(major%10);
 	bootname[7]=0;
 
-	LONG bootPri = (part->pb_Flags & PBFF_BOOTABLE) ? pp->de.de_BootPri: -128; 
-	
-	if(strncmp(name, "BOOT", 4)==0)   // does it start with BOOT?
-	{
-	  if(CompareBSTRNoCase(part->pb_DriveName, bootname)==TRUE)   // is there a 'drivename' for this kickstart?
-	  {
-	    bootPri++;                    // make priority a bit higher
-	  }
+	if (!(part->pb_Flags & PBFF_BOOTABLE)) {
+		bootPri = -128;
+	} else {
+		bootPri = pp->de.de_BootPri;
+		// is there a 'drivename' for this kickstart?
+		if(CompareBSTRNoCase(part->pb_DriveName, bootname)==TRUE) {
+			bootPri++; // make priority a bit higher
+		}
 	}
 
 	if (ExpansionBase->LibNode.lib_Version >= 37) {

--- a/mounter.c
+++ b/mounter.c
@@ -838,8 +838,30 @@ static void AddNode(struct PartitionBlock *part, struct ParameterPacket *pp, str
 	struct ExecBase *SysBase = md->SysBase;
 	struct ExpansionBase *ExpansionBase = md->ExpansionBase;
 	struct DosLibrary *DOSBase = md->DOSBase;
+	
+	char bootname[8];
+	UWORD major;
+	
+	major=(ExpansionBase->LibNode.lib_Version)%100;         // we assume versionnumber is under 100, but better safe then sorry
+	bootname[0]=0x06;
+	bootname[1]='B';
+	bootname[2]='O';
+        bootname[3]='O';
+  	bootname[4]='T';
+	bootname[5]=0x30+(major/10);
+	bootname[6]=0x30+(major%10);
+	bootname[7]=0;
 
-	LONG bootPri = (part->pb_Flags & PBFF_BOOTABLE) ? pp->de.de_BootPri : -128;
+	LONG bootPri = (part->pb_Flags & PBFF_BOOTABLE) ? pp->de.de_BootPri: -128; 
+	
+	if(strncmp(name, "BOOT", 4)==0)   // does it start with BOOT?
+	{
+	  if(CompareBSTRNoCase(part->pb_DriveName, bootname)==TRUE)   // is there a 'drivename' for this kickstart?
+	  {
+	    bootPri++;                    // make priority a bit higher
+	  }
+	}
+
 	if (ExpansionBase->LibNode.lib_Version >= 37) {
 		// KS 2.0+
 		if (!md->DOSBase && bootPri > -128) {


### PR DESCRIPTION
This PR will enable to raise the bootPriority of a given partition when it matches the Kickstart version. This will prevent swapping the harddisks/compact flashcards in and out when using a different the Kickstart.

The partition name need to start with BOOT followed by the major version, eg 'BOOT34' for Kckstart 1.3 and 'BOOT37' for Kickstart 2.0. The assigned priority (written with HDtoolbox) is raised with 1 when it matches the current Kickstart version.

Hope you find it usefull as an extra feature for your excellent driver.